### PR TITLE
Adhere to naming and style guide for packages

### DIFF
--- a/src/Fullscreen.elm
+++ b/src/Fullscreen.elm
@@ -8,11 +8,12 @@ import Task exposing (Task)
 
 import Native.Fullscreen
 
+
 {-|
-Active - The page is currently in Fullscreen Mode.
-RequestAvailable - The page is in a state where Fullscreen Mode can be requested.
-RequestUnvailable - The page is not a state where Fullscreen Mode can be requested.
-Unsupported - This browser does not support the Fullscreen API.
+  * Active - The page is currently in Fullscreen Mode.
+  * RequestAvailable - The page is in a state where Fullscreen Mode can be requested.
+  * RequestUnvailable - The page is not a state where Fullscreen Mode can be requested.
+  * Unsupported - This browser does not support the Fullscreen API.
 -}
 type Status
   = Active
@@ -20,28 +21,34 @@ type Status
   | RequestUnavailable
   | Unsupported
 
+
 {-|
 A signal of Booleans representing whether Fullscreen Mode is active. It begins
 False and switches to True or False as appropriate whenever a `fullscreenchange`
 event is fired on the document.
 -}
-fullscreenActive : Signal Bool
-fullscreenActive = Native.Fullscreen.fullscreenMode
+isActive : Signal Bool
+isActive =
+  Native.Fullscreen.fullscreenMode
 
-{-|
-Requests that the document enter Fullscreen Mode.
--}
-requestFullscreen : Task error ()
-requestFullscreen = Native.Fullscreen.requestFullscreen
 
-{-|
-Requests that the document enter Fullscreen Mode.
+{-| Requests that the document enter Fullscreen Mode.
 -}
-exitFullscreen : Task error ()
-exitFullscreen = Native.Fullscreen.exitFullscreen
+request : Task error ()
+request =
+  Native.Fullscreen.requestFullscreen
+
+
+{-| Requests that the document enter Fullscreen Mode.
+-}
+exit : Task error ()
+exit =
+  Native.Fullscreen.exitFullscreen
+
 
 {-|
 Checks the document's current fullscreen status.
 -}
-checkStatus : Task error Status
-checkStatus = Native.Fullscreen.checkStatus
+status : Task error Status
+status =
+  Native.Fullscreen.checkStatus


### PR DESCRIPTION
Style guide is not formalized, but [this rule](http://package.elm-lang.org/help/design-guidelines#module-names-should-not-reappear-in-function-names) should be followed at least!

Also, I would expert most users to use this package qualified, so you would see uses such as `Fullscreen.request` and `Fullscreen.isActive` which is waaaaaaay nicer than `Fullscreen.requestFullscreen`
